### PR TITLE
Require authentication for only /user/profile and /user/sign-out

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -39,7 +39,8 @@ var (
 				group.Group("/", func(group *ghttp.RouterGroup) {
 					group.Middleware(service.Middleware().Auth)
 					group.ALLMap(g.Map{
-						"/user/profile": userCtrl,
+						"/user/profile":  userCtrl.Profile,
+						"/user/sign-out": userCtrl.SignOut,
 					})
 				})
 			})


### PR DESCRIPTION
Only need authentication for  /user/profile and /user/sign-out.

**Old**
![Screenshot from 2023-09-20 17-30-24](https://github.com/gogf/gf-demo-user/assets/44580870/84b35eec-03de-4135-8520-a156bd61436f)

**New**
![Screenshot from 2023-09-20 17-31-30](https://github.com/gogf/gf-demo-user/assets/44580870/b802865b-f27f-4a7a-9d8f-052fb8fa0df4)
